### PR TITLE
feat: support lzw compression tiffs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setuptools.setup(
         "requests >= 2",
         "scikit-image",  # TODO use pillow instead
         "tqdm ~= 4.29",
+        'imagecodecs', # required by scikit-image to read LZW compressed tiff files
     ],
     python_requires="~= 3.5",
     extras_require={


### PR DESCRIPTION
`scikit-image` does not seem to support lzw tiff out of the box. `imagecodecs` seems to be needed as a peer dependency.

see https://gis.stackexchange.com/a/387190

edit: partially fixes #13 