### PR TITLE
feat: support rgb nifti

### DIFF
--- a/src/neuroglancer_scripts/data_types.py
+++ b/src/neuroglancer_scripts/data_types.py
@@ -17,7 +17,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-
+NG_MULTICHANNEL_DATATYPES = (('R', 'G', 'B'),)
 NG_INTEGER_DATA_TYPES = ("uint8", "uint16", "uint32", "uint64")
 NG_DATA_TYPES = NG_INTEGER_DATA_TYPES + ("float32",)
 
@@ -77,3 +77,20 @@ def get_chunk_dtype_transformer(input_dtype, output_dtype, warn=True):
         return chunk.astype(output_dtype, casting="unsafe")
 
     return chunk_transformer
+
+
+def get_dtype_from_vol(volume):
+    zero_index = tuple(0 for _ in volume.shape)
+    return get_dtype(volume[zero_index].dtype)
+
+
+def get_dtype(input_dtype):
+    if input_dtype.names is None:
+        return input_dtype, False
+    if input_dtype.names not in NG_MULTICHANNEL_DATATYPES:
+        err = 'tuple datatype {} not yet supported'.format(input_dtype.names)
+        raise NotImplementedError(err)
+    for index, value in enumerate(input_dtype.names):
+        err = 'Multichanneled datatype should have the same datatype'
+        assert input_dtype[index].name == input_dtype[0].name, err
+    return input_dtype[0], True

--- a/unit_tests/test_data_types.py
+++ b/unit_tests/test_data_types.py
@@ -10,6 +10,7 @@ from neuroglancer_scripts.data_types import (
     NG_DATA_TYPES,
     NG_INTEGER_DATA_TYPES,
     get_chunk_dtype_transformer,
+    get_dtype,
 )
 
 
@@ -132,3 +133,24 @@ def test_dtype_conversion_integer_downcasting(dtype):
         np.array([iinfo.min, iinfo.min,
                   iinfo.max, iinfo.max], dtype=dtype)
     )
+
+
+def test_unsupported_tupled_dtype():
+
+    random_val = np.random.rand(81).reshape((3, 3, 3, 3)) * 255
+    random_val = random_val.astype(np.uint8)
+    wrong_type = np.dtype([('A', 'u1'), ('B', 'u1'), ('C', 'u1')])
+    new_data = random_val.copy().view(dtype=wrong_type).reshape((3, 3, 3))
+
+    with pytest.raises(NotImplementedError):
+        get_dtype(new_data.dtype)
+
+
+def test_supported_tupled_dtype():
+    random_val = np.random.rand(81).reshape((3, 3, 3, 3)) * 255
+    random_val = random_val.astype(np.uint8)
+    right_type = np.dtype([('R', 'u1'), ('G', 'u1'), ('B', 'u1')])
+    new_data = random_val.copy().view(dtype=right_type).reshape((3, 3, 3))
+    dtype, isrgb = get_dtype(new_data.dtype)
+    assert dtype.name == 'uint8'
+    assert isrgb


### PR DESCRIPTION
partial fixes #13 

nibabel reading rgb nifti does not read the dataarray as [x, y, z, 3] numpy array, but instead as [x, y, z] numpy array, with datatype as `[(R, dtype), (G, dtype), (B, dtype)]`. 

This breaks the built in datatype check of neuroglancer-scripts. 

This PR checks for this datatype, and patches the necessary parameters:

- when writing `info_fullres.json`, adds an additional dimension, so `num_channel` is correctly set to 3
- when reading nifti & writing chunks, it reshape the data from [x,y,z] to [x,y,z,3] (not via the native `.reshape` method, but with `.view` -> slice manually, which seems to be faster)

Admittedly, the second approach is very naive. I would welcome any feedbacks on doing it more efficiently.
