### PR TITLE
feat: push releases to pypi

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Publish release to pypi
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+
+    - name: Build the package
+      run: |
+        echo "Installing and upgrading twine, setuptools and wheel"
+        python -m pip install --user --upgrade twine setuptools wheel
+        echo "Package the project"
+        python setup.py sdist bdist_wheel
+    - name: Prepare pypi settings
+      run: |
+        echo "[pypi]" >~/.pypirc
+        echo "username = __token__" >>~/.pypirc
+        echo "password = ${{ secrets.PYPI_PUSH }}" >>~/.pypirc
+    - name: Upload to pypi
+      run: |
+        echo "Uploading to pypi"
+        python -m twine upload dist/*

--- a/unit_tests/test_volume_reader.py
+++ b/unit_tests/test_volume_reader.py
@@ -1,0 +1,55 @@
+import nibabel as nib
+import numpy as np
+import pytest
+import json
+from unittest.mock import patch
+from neuroglancer_scripts.volume_reader import nibabel_image_to_info, \
+    volume_file_to_precomputed
+
+
+def prepare_nifti_images():
+
+    random_rgb_val = np.random.rand(81).reshape((3, 3, 3, 3)) * 255
+    random_rgb_val = random_rgb_val.astype(np.uint8)
+    right_type = np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])
+    new_data = random_rgb_val.copy().view(dtype=right_type).reshape((3, 3, 3))
+    rgb_img = nib.Nifti1Image(new_data, np.eye(4))
+
+    random_uint8_val = np.random.rand(27).reshape((3, 3, 3)) * 255
+    random_uint8_val = random_uint8_val.astype(np.uint8)
+    uint8_img = nib.Nifti1Image(random_uint8_val, np.eye(4))
+
+    return [(rgb_img, 3), (uint8_img, 1)]
+
+
+@pytest.mark.parametrize("nifti_img,expected_num_channel",
+                         prepare_nifti_images())
+def test_nibabel_image_to_info(nifti_img, expected_num_channel):
+
+    formatted_info, _, _, _ = nibabel_image_to_info(nifti_img)
+    info = json.loads(formatted_info)
+    assert info.get("num_channels") == expected_num_channel
+
+
+@pytest.mark.parametrize("nifti_img,expected_num_channel",
+                         prepare_nifti_images())
+@patch('neuroglancer_scripts.precomputed_io.get_IO_for_existing_dataset',
+       return_value=None)
+@patch('neuroglancer_scripts.volume_reader.nibabel_image_to_precomputed')
+@patch("nibabel.load")
+def test_volume_file_to_precomputed(m_nib_load, m_nib_img_precomp, _,
+                                    nifti_img, expected_num_channel):
+    m_nib_load.return_value = nifti_img
+    m_nib_img_precomp.return_value = "hoho"
+    volume_file_to_precomputed("mock_file_name", "./bla")
+
+    assert m_nib_load.called
+    assert m_nib_img_precomp.called
+
+    nibabel_image = m_nib_img_precomp.call_args[0][0]
+
+    if expected_num_channel == 1:
+        assert nibabel_image is nifti_img
+    else:
+        assert nibabel_image is not nifti_img
+        assert len(nibabel_image.dataobj.shape) == 4


### PR DESCRIPTION
This PR:

- add some of the missing tests for nifti rgb support
- adds workflow that automatically builds and pushes **releases** to pypi

## Before this PR should be merged...

please:

- check if the build step:

```sh
python -m pip install -U pip
python -m pip install --user --upgrade twine setuptools wheel
python setup.py sdist bdist_wheel
```

and upload step:

```sh
python -m twine upload dist/*
```

are correct.

- create a token (log into pypi > [USERNAME]  > Your projects  > neuroglancer-scripts [manage] > Settings > Create a token for neuroglancer-scripts )
- Add the said token as as a secret with the name `PYPI_PUSH` in github (Settings > Secrets > New repository secret)

(It should be noted that the token, once generated, and saved, cannot be viewed in plain text by any one. Should a token be lost, it can always be revoked at pypi and a new one generated.)