### PR TITLE
Separate PIP cache by Python version

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}
+        key: ${{ runner.os }}-pip-python${{ matrix.python-version }}-${{ hashFiles('setup.cfg') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Install dependencies


### PR DESCRIPTION
Parallel tests of multiple Python version create a race condition for the cache creation, which can prevent Python 3.10 from saving the compiled wheels to cache (which is the real reason for having a cache in the first place).