### PR TITLE
bugfix: erroneous implementation of reading RGB nifti

### DIFF
--- a/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
+++ b/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
@@ -9,8 +9,6 @@ import json
 import logging
 import sys
 
-import nibabel
-
 import neuroglancer_scripts.accessor
 import neuroglancer_scripts.chunk_encoding
 import neuroglancer_scripts.downscaling
@@ -30,7 +28,8 @@ def volume_to_precomputed_pyramid(volume_filename,
                                   input_max=None,
                                   load_full_volume=True,
                                   options={}):
-    img = nibabel.load(volume_filename)
+    img = volume_reader.nibabel_load_proxy(volume_filename)
+
     formatted_info, _, _, _ = volume_reader.nibabel_image_to_info(
         img,
         ignore_scaling=ignore_scaling,

--- a/src/neuroglancer_scripts/volume_reader.py
+++ b/src/neuroglancer_scripts/volume_reader.py
@@ -308,11 +308,10 @@ def volume_file_to_precomputed(volume_filename,
     if is_rgb:
         proxy = np.asarray(img.dataobj)
         new_proxy = proxy.view(dtype=np.uint8, type=np.ndarray)
-        third = int(new_proxy.shape[0] / 3)
         new_dataobj = np.stack([
-            new_proxy[0:third],
-            new_proxy[third:2*third],
-            new_proxy[2*third:]
+            new_proxy[:, :, 0::3],
+            new_proxy[:, :, 1::3],
+            new_proxy[:, :, 2::3]
         ], axis=-1)
         img = nibabel.Nifti1Image(new_dataobj, img.affine)
 

--- a/src/neuroglancer_scripts/volume_reader.py
+++ b/src/neuroglancer_scripts/volume_reader.py
@@ -307,12 +307,20 @@ def volume_file_to_precomputed(volume_filename,
                         img.dataobj)
     if is_rgb:
         proxy = np.asarray(img.dataobj)
+        is_fortran = np.isfortran(proxy)
         new_proxy = proxy.view(dtype=np.uint8, type=np.ndarray)
-        new_dataobj = np.stack([
-            new_proxy[:, :, 0::3],
-            new_proxy[:, :, 1::3],
-            new_proxy[:, :, 2::3]
-        ], axis=-1)
+        if is_fortran:
+            new_dataobj = np.stack([
+                new_proxy[0::3, :, :],
+                new_proxy[1::3, :, :],
+                new_proxy[2::3, :, :]
+            ], axis=-1)
+        else:
+            new_dataobj = np.stack([
+                new_proxy[:, :, 0::3],
+                new_proxy[:, :, 1::3],
+                new_proxy[:, :, 2::3]
+            ], axis=-1)
         img = nibabel.Nifti1Image(new_dataobj, img.affine)
 
     accessor = neuroglancer_scripts.accessor.get_accessor_for_url(

--- a/unit_tests/test_volume_reader.py
+++ b/unit_tests/test_volume_reader.py
@@ -11,27 +11,24 @@ def prepare_nifti_images():
     width = 5
     height = 4
     depth = 7
+
     dim = (width, height, depth)
     mul_dim = width * height * depth
 
-    """
-    bugfix: rgb nifti reading bug
-    tests: added tests for arbitary dimension rgb nii
-    tests: added testing values before and after volume_file_to_precomputed
-
-    previous implementation of reading rgb nii was errorneous.
-    """
     random_rgb_val = np.random.rand(mul_dim * 3).reshape(*dim, 3) * 255
     random_rgb_val = random_rgb_val.astype(np.uint8)
     right_type = np.dtype([("R", "u1"), ("G", "u1"), ("B", "u1")])
     new_data = random_rgb_val.copy().view(dtype=right_type).reshape(dim)
     rgb_img = nib.Nifti1Image(new_data, np.eye(4))
 
+    fortrain_rgb = np.array(new_data, order="F")
+    fortrain_img = nib.Nifti1Image(fortrain_rgb, np.eye(4))
+
     random_uint8_val = np.random.rand(mul_dim).reshape(dim) * 255
     random_uint8_val = random_uint8_val.astype(np.uint8)
     uint8_img = nib.Nifti1Image(random_uint8_val, np.eye(4))
 
-    return [(rgb_img, 3), (uint8_img, 1)]
+    return [(rgb_img, 3), (uint8_img, 1), (fortrain_img, 3)]
 
 
 @pytest.mark.parametrize("nifti_img,expected_num_channel",


### PR DESCRIPTION
bugfix: rgb nifti bug
tests: added tests for arbitary dimension rgb nii
tests: added testing values before and after volume_file_to_precomputed

previous implementation of reading rgb nii was errorneous.