### PR TITLE
Add Gzip compresslevel option to FileAccessor and command line

### DIFF
--- a/src/neuroglancer_scripts/accessor.py
+++ b/src/neuroglancer_scripts/accessor.py
@@ -69,7 +69,7 @@ def add_argparse_options(parser, write_chunks=True, write_files=True):
         group.add_argument("--no-gzip", "--no-compression",
                            action="store_false", dest="gzip",
                            help="Don't gzip the output.")
-        group.add_argument("--compresslevel", type=int, default=0, choices=range(0,10),
+        group.add_argument("--compresslevel", type=int, default=9, choices=range(0,10),
                            help="The compression level is used for the Gzip")
     if write_chunks:
         group.add_argument(

--- a/src/neuroglancer_scripts/accessor.py
+++ b/src/neuroglancer_scripts/accessor.py
@@ -37,8 +37,9 @@ def get_accessor_for_url(url, accessor_options={}):
         from neuroglancer_scripts import file_accessor
         flat = accessor_options.get("flat", False)
         gzip = accessor_options.get("gzip", True)
+        compresslevel = accessor_options.get("compresslevel", 9)
         pathname = _convert_split_file_url_to_pathname(r)
-        return file_accessor.FileAccessor(pathname, flat=flat, gzip=gzip)
+        return file_accessor.FileAccessor(pathname, flat=flat, gzip=gzip, compresslevel=compresslevel)
     elif r.scheme in ("http", "https"):
         from neuroglancer_scripts import http_accessor
         return http_accessor.HttpAccessor(url)
@@ -68,6 +69,8 @@ def add_argparse_options(parser, write_chunks=True, write_files=True):
         group.add_argument("--no-gzip", "--no-compression",
                            action="store_false", dest="gzip",
                            help="Don't gzip the output.")
+        group.add_argument("--compresslevel", type=int, default=0, choices=range(0,10),
+                           help="The compression level is used for the Gzip")
     if write_chunks:
         group.add_argument(
             "--flat", action="store_true",

--- a/src/neuroglancer_scripts/file_accessor.py
+++ b/src/neuroglancer_scripts/file_accessor.py
@@ -42,13 +42,14 @@ class FileAccessor(neuroglancer_scripts.accessor.Accessor):
     can_read = True
     can_write = True
 
-    def __init__(self, base_dir, flat=False, gzip=True):
+    def __init__(self, base_dir, flat=False, gzip=True, compresslevel=9):
         self.base_path = pathlib.Path(base_dir)
         if flat:
             self.chunk_pattern = _CHUNK_PATTERN_FLAT
         else:
             self.chunk_pattern = _CHUNK_PATTERN_SUBDIR
         self.gzip = gzip
+        self.compresslevel = compresslevel
 
     def file_exists(self, relative_path):
         relative_path = pathlib.Path(relative_path)
@@ -101,7 +102,7 @@ class FileAccessor(neuroglancer_scripts.accessor.Accessor):
             if self.gzip and mime_type not in NO_COMPRESS_MIME_TYPES:
                 with gzip.open(
                         str(file_path.with_name(file_path.name + ".gz")),
-                        mode) as f:
+                        mode, compresslevel=self.compresslevel) as f:
                     f.write(buf)
             else:
                 with file_path.open(mode) as f:
@@ -146,7 +147,7 @@ class FileAccessor(neuroglancer_scripts.accessor.Accessor):
             if self.gzip and mime_type not in NO_COMPRESS_MIME_TYPES:
                 with gzip.open(
                         str(chunk_path.with_name(chunk_path.name + ".gz")),
-                        mode) as f:
+                        mode, compresslevel=self.compresslevel) as f:
                     f.write(buf)
             else:
                 with chunk_path.open(mode) as f:

--- a/unit_tests/test_file_accessor.py
+++ b/unit_tests/test_file_accessor.py
@@ -12,11 +12,11 @@ from neuroglancer_scripts.accessor import (
     DataAccessError,
 )
 
-
+@pytest.mark.parametrize("compresslevel", [1,5,9])
 @pytest.mark.parametrize("flat", [False, True])
 @pytest.mark.parametrize("gzip", [False, True])
-def test_file_accessor_roundtrip(tmpdir, gzip, flat):
-    a = FileAccessor(str(tmpdir), gzip=gzip, flat=flat)
+def test_file_accessor_roundtrip(tmpdir, gzip, flat, compresslevel):
+    a = FileAccessor(str(tmpdir), gzip=gzip, flat=flat, compresslevel=compresslevel)
     fake_info = b'{"scales": [{"key": "key"}]}'
     fake_chunk_buf = b"d a t a"
     chunk_coords = (0, 1, 0, 1, 0, 1)


### PR DESCRIPTION
Add compression level option for gzip compression to reduce pyramid generation time from hours to minutes.

The Python gzip library is defaulting to compression level 9. For a specific EM data test, the gzip level 9 takes 168 min while gzip compression level 1 takes 9m50s with the compressed data size being approximately the same.