### PR TITLE
Restrict nibable to compatible versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ package_dir =
 packages = find:
 python_requires = ~=3.5
 install_requires =
-    nibabel >= 2
+    nibabel >= 2, <5
     numpy >= 1.11.0
     pillow >= 1.1.6
     requests >= 2


### PR DESCRIPTION
Ran into CI testing error when the latest version of NIbabel was installed:
```
File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/neuroglancer_scripts/volume_reader.py", line 290, in nibabel_image_to_precomputed
[273](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:274)
    volume = img.get_data()
[274](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:275)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/nibabel/deprecator.py", line 185, in deprecated_func
[275](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:276)
    raise error_class(message)
[276](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:277)
nibabel.deprecator.ExpiredDeprecationError: get_data() is deprecated in favor of get_fdata(), which has a more predictable return type. To obtain get_data() behavior going forward, use numpy.asanyarray(img.dataobj).
[277](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:278)

[278](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:279)
* deprecated from version: 3.0
[279](https://github.com/niaid/tomojs-pytools/actions/runs/4175708111/jobs/7231009526#step:8:280)
* Raises <class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0
```