### PR TITLE
fix nibabel get_data deprecation

### DIFF
--- a/src/neuroglancer_scripts/volume_reader.py
+++ b/src/neuroglancer_scripts/volume_reader.py
@@ -287,7 +287,7 @@ def nibabel_image_to_precomputed(img,
     )
     if load_full_volume:
         logger.info("Loading full volume to memory... ")
-        volume = img.get_data()
+        volume = np.asanyarray(img.dataobj)
     else:
         volume = proxy
     logger.info("Writing chunks... ")


### PR DESCRIPTION
per https://nipy.org/nibabel/reference/nibabel.dataobj_images.html#nibabel.dataobj_images.DataobjImage.get_data `nibabel.get_data` will raise Exception as of >=5.0

Per suggestion, this PR now uses `numpy.asanyarray(img.dataobj)`

another option is `img.get_fdata(img.header.get_data_dtype())`