### PR TITLE
feat: add data_type and encoding to volume to pyramid function

### DIFF
--- a/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
+++ b/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
@@ -113,7 +113,18 @@ omitted, it is assumed to be zero.
     group.add_argument("--input-max", type=float, default=None,
                        help="input value that will be mapped to the maximum "
                        "output value")
-
+    group.add_argument("--type", default=None,
+                        choices=("image", "segmentation"),
+                        help="Type of dataset (image or segmentation). By"
+                        " default this is inherited from the fullres_info"
+                        " file, with a fallback to image.")
+    group.add_argument("--encoding", default=None,
+                        choices=("raw", "jpeg", "compressed_segmentation"),
+                        help="data encoding (raw, jpeg, or"
+                        " compressed_segmentation). By default this is"
+                        " inherited from the fullres_info file, with a"
+                        " fallback to raw.")
+    
     neuroglancer_scripts.accessor.add_argparse_options(parser)
     neuroglancer_scripts.downscaling.add_argparse_options(parser)
     neuroglancer_scripts.chunk_encoding.add_argparse_options(parser,
@@ -141,6 +152,8 @@ def main(argv=sys.argv):
         input_min=args.input_min,
         input_max=args.input_max,
         load_full_volume=args.load_full_volume,
+        dataset_type=args.type,
+        encoding=args.encoding,
         options=vars(args)
     ) or 0
 

--- a/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
+++ b/src/neuroglancer_scripts/scripts/volume_to_precomputed_pyramid.py
@@ -15,6 +15,7 @@ import neuroglancer_scripts.accessor
 import neuroglancer_scripts.chunk_encoding
 import neuroglancer_scripts.downscaling
 import neuroglancer_scripts.dyadic_pyramid
+import neuroglancer_scripts.scripts.generate_scales_info
 from neuroglancer_scripts import precomputed_io
 from neuroglancer_scripts import volume_reader
 
@@ -29,6 +30,8 @@ def volume_to_precomputed_pyramid(volume_filename,
                                   input_min=None,
                                   input_max=None,
                                   load_full_volume=True,
+                                  dataset_type=None,
+                                  encoding=None,
                                   options={}):
     img = nibabel.load(volume_filename)
     formatted_info, _, _, _ = volume_reader.nibabel_image_to_info(
@@ -42,7 +45,11 @@ def volume_to_precomputed_pyramid(volume_filename,
     accessor = neuroglancer_scripts.accessor.get_accessor_for_url(
         dest_url, options
     )
-    # TODO fill encoding...
+    neuroglancer_scripts.scripts.generate_scales_info.set_info_params(
+        info,
+        dataset_type=dataset_type,
+        encoding=encoding
+    )
     neuroglancer_scripts.dyadic_pyramid.fill_scales_for_dyadic_pyramid(
         info
     )


### PR DESCRIPTION
This PR adds `data_type` and `encoding` to `volume-to-precomputed-pyramid`