### PR TITLE
enh: improve read perf of http accessor by using requests.Session

### DIFF
--- a/src/neuroglancer_scripts/http_accessor.py
+++ b/src/neuroglancer_scripts/http_accessor.py
@@ -35,6 +35,8 @@ class HttpAccessor(neuroglancer_scripts.accessor.Accessor):
     can_write = False
 
     def __init__(self, base_url):
+        self._session = requests.Session()
+
         # Fix the base URL to end with a slash, discard query and fragment
         r = urllib.parse.urlsplit(base_url)
         self.base_url = urllib.parse.urlunsplit((
@@ -55,7 +57,7 @@ class HttpAccessor(neuroglancer_scripts.accessor.Accessor):
     def file_exists(self, relative_path):
         file_url = self.base_url + relative_path
         try:
-            r = requests.head(file_url)
+            r = self._session.head(file_url)
             if r.status_code == requests.codes.not_found:
                 return False
             r.raise_for_status()
@@ -67,7 +69,7 @@ class HttpAccessor(neuroglancer_scripts.accessor.Accessor):
     def fetch_file(self, relative_path):
         file_url = self.base_url + relative_path
         try:
-            r = requests.get(file_url)
+            r = self._session.get(file_url)
             r.raise_for_status()
         except requests.exceptions.RequestException as exc:
             raise DataAccessError("Error reading {0}: {1}"


### PR DESCRIPTION
According to https://requests.readthedocs.io/en/latest/user/advanced/#session-objects , it appears that by using `requests.Session`, the underlying TCP connection will be reused, which should drastically improve repeated get requests to the same host.

From the (admittedly) rough test script[1], we see promising improvement (execution time cut by ~50% in sync reads and ~30% in threaded reads) [2]


[1] rough script used for testing both sync and threaded operations, we used `time python <script_name>.py` and manually recorded the result

```python
from neuroglancer_scripts.http_accessor import HttpAccessor
from concurrent.futures import ThreadPoolExecutor
from itertools import repeat

multiple = 2

def get_args():
    return [
        (x, x+64, y, y+64, z, z+64)
        for x in range(0, 64*multiple, 64)
        for y in range(0, 64*multiple, 64)
        for z in range(0, 64*multiple, 64)
    ]

def main():
    accessor = HttpAccessor("https://neuroglancer.humanbrainproject.eu/precomputed/BigBrainRelease.2015/8bit")
    for arg in get_args:
        accessor.fetch_chunk("20um",arg)

def threaded():
    accessor = HttpAccessor("https://neuroglancer.humanbrainproject.eu/precomputed/BigBrainRelease.2015/8bit")
    with ThreadPoolExecutor(max_workers=4) as ex:
        for val in ex.map(
            accessor.fetch_chunk,
            repeat("20um"),
            get_args()
        ): pass
```

[2] truncated result

| multiple | sync or threaded | previous | current |
| --- | --- | --- | --- |
| 2 | sync | 0m0.766s | 0m0.315s |
| 10 | sync | 1m24.788s | 0m24.446s |
| 2 | threaded | 0m0.336s | 0m0.207s | 
| 10 | threaded | 0m24.379s | 0m6.099s |